### PR TITLE
Proof of concept object nodepath caching

### DIFF
--- a/core/object/object.h
+++ b/core/object/object.h
@@ -627,6 +627,8 @@ private:
 	bool _edited = false;
 	uint32_t _edited_version = 0;
 	HashSet<String> editor_section_folding;
+	mutable HashMap<NodePath, String> nodepath_property_cache;
+	void _update_nodepath_cache_recursive(const PropertyInfo &p_info, const Variant &p_variant) const;
 #endif
 	ScriptInstance *script_instance = nullptr;
 	Variant script; // Reference does not exist yet, store it in a Variant.
@@ -966,7 +968,7 @@ public:
 	bool editor_is_section_unfolded(const String &p_section);
 	const HashSet<String> &editor_get_section_folding() const { return editor_section_folding; }
 	void editor_clear_section_folding() { editor_section_folding.clear(); }
-
+	bool editor_property_has_nodepath(const NodePath &p_path);
 #endif
 
 	// Used by script languages to store binding data.

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -2071,6 +2071,18 @@ void SceneTreeDock::perform_node_renames(Node *p_base, HashMap<Node *, NodePath>
 		return;
 	}
 
+	bool any = false;
+	for (KeyValue<Node *, NodePath> K : *p_renames) {
+		NodePath path = p_base->get_path().rel_path_to(K.key->get_path());
+		if (p_base->editor_property_has_nodepath(path)) {
+			any = true;
+		}
+	}
+
+	if (!any) {
+		return;
+	}
+
 	// No renaming if base node is deleted.
 	HashMap<Node *, NodePath>::Iterator found_base_path = p_renames->find(p_base);
 	if (found_base_path && found_base_path->value.is_empty()) {


### PR DESCRIPTION
Just in case you haven't already implemented something which fulfills a similar purpose. So far I've only tested basic rename cases propagating to properties, and in the Wildeburn project this makes moves and renames extremely fast. It does have a few weaknesses such as not quite duplicated code between recursively building the cache and recursively doing the rename, increasing memory overhead if a project very heavily uses NodePaths, and pretty simplistic checking of paths against the cache.

I think ideally rather than this incremental solution there would be a direct link tracked by each node for each property which is directly referencing it via NodePath while in the editor, but I didn't want to mess with the existing logic too much, just filter out recursive calls which were not going to do anything.